### PR TITLE
Changed Position for CTA

### DIFF
--- a/templates/admin_homepage.html
+++ b/templates/admin_homepage.html
@@ -51,7 +51,6 @@
         </div>
     </div>
     <script src="{{ url_for('static', filename='js/script_UserHome.js') }}">
-        
     </script>
 </body>
 </html>

--- a/templates/ca_info.html
+++ b/templates/ca_info.html
@@ -23,11 +23,7 @@
             description="CA work at Colby College"
           />
         </div>
-        <div class="cta-box">
-          <a href="/requirements" class="cta-link"
-            >Click here to see the requirements to be a CA</a>
-        </div>
-
+       
         <div class="description-box">
           <h2>Role of a Community Advisor</h2>
           <p>
@@ -99,6 +95,11 @@
           </p>
         </div>
       </div>
+      <div class="cta-box">
+          <a href="/requirements" class="cta-link"
+            >Click here to see the requirements to be a CA</a>
+        </div>
+
     </div>
   </body>
 </html>


### PR DESCRIPTION
This pull request includes changes to the HTML templates for the admin homepage and the CA information page. The most important changes involve the removal and re-addition of a call-to-action (CTA) box on the CA information page.

Changes to `templates/admin_homepage.html`:

* Removed an unnecessary empty line inside the script tag.

Changes to `templates/ca_info.html`:

* Removed the CTA box linking to the requirements page from its original position.
* Re-added the CTA box linking to the requirements page at the end of the document.