### PR TITLE
Fixed the deployment error from Heroku 

### DIFF
--- a/models.py
+++ b/models.py
@@ -24,7 +24,7 @@ class Appointment(db.Model):
     __tablename__ = 'appointment'
 
     id = db.Column(db.Integer, primary_key=True)
-    student_id = db.Column(db.String, db.ForeignKey('applicant_information.student_id'), nullable=False)
+    student_id = db.Column(db.String(50), db.ForeignKey('applicant_information.student_id'), nullable=False)
     date = db.Column(db.Date, nullable=False)
     time = db.Column(db.Time, nullable=False)
 
@@ -37,25 +37,25 @@ class ApplicantInformation(db.Model):
     __tablename__ = 'applicant_information'
     
     id = db.Column(db.Integer, primary_key=True)
-    last_name = db.Column(db.String, nullable=False)
-    first_name = db.Column(db.String, nullable=False)
-    preferred_name = db.Column(db.String, nullable=True)
-    pronouns = db.Column(db.String, nullable=False)
-    student_id = db.Column(db.String, unique=True, nullable=False)
-    current_hall = db.Column(db.String, nullable=False)
-    current_room_number = db.Column(db.String, nullable=False)
-    current_email = db.Column(db.String, nullable=False)
-    current_phone_number = db.Column(db.String, nullable=False)
-    returning_ca_or_new_ca = db.Column(db.String, nullable=False)
-    major_1 = db.Column(db.String, nullable=False)
-    major_2 = db.Column(db.String, nullable=True)
-    minor_1 = db.Column(db.String, nullable=True)
-    minor_2 = db.Column(db.String, nullable=True)
-    class_year = db.Column(db.String, nullable=False)
+    last_name = db.Column(db.String(100), nullable=False)
+    first_name = db.Column(db.String(100), nullable=False)
+    preferred_name = db.Column(db.String(100), nullable=True)
+    pronouns = db.Column(db.String(50), nullable=False)
+    student_id = db.Column(db.String(50), unique=True, nullable=False)
+    current_hall = db.Column(db.String(100), nullable=False)
+    current_room_number = db.Column(db.String(20), nullable=False)
+    current_email = db.Column(db.String(255), nullable=False)
+    current_phone_number = db.Column(db.String(20), nullable=False)
+    returning_ca_or_new_ca = db.Column(db.String(20), nullable=False)
+    major_1 = db.Column(db.String(100), nullable=False)
+    major_2 = db.Column(db.String(100), nullable=True)
+    minor_1 = db.Column(db.String(100), nullable=True)
+    minor_2 = db.Column(db.String(100), nullable=True)
+    class_year = db.Column(db.String(20), nullable=False)
     cumulative_gpa = db.Column(db.Float, nullable=False)
     leadership_experience = db.Column(db.PickleType, nullable=False)
-    application_status = db.Column(db.String, default='Submitted', nullable=False)
-    assessment_status = db.Column(db.String, default='Yet to Be Assessed', nullable=False)
+    application_status = db.Column(db.String(50), default='Submitted', nullable=False)
+    assessment_status = db.Column(db.String(50), default='Yet to Be Assessed', nullable=False)
 
     # Relationships
     preferences = db.relationship('ApplicantPreferences', backref='applicant', uselist=False)
@@ -75,16 +75,16 @@ class ApplicantPreferences(db.Model):
     
     id = db.Column(db.Integer, primary_key=True)
     substance_free_housing_interest = db.Column(db.Integer, nullable=False)
-    healthy_colby_interest = db.Column(db.String, nullable=False)
-    population_interest = db.Column(db.String, nullable=False)
+    healthy_colby_interest = db.Column(db.String(100), nullable=False)
+    population_interest = db.Column(db.String(100), nullable=False)
     staff_interest = db.Column(db.PickleType, nullable=False) 
-    illc_interest = db.Column(db.String, nullable=False)
-    student_id = db.Column(db.String, db.ForeignKey('applicant_information.student_id'), nullable=False)
+    illc_interest = db.Column(db.String(100), nullable=False)
+    student_id = db.Column(db.String(50), db.ForeignKey('applicant_information.student_id'), nullable=False)
 
 class AdditionalInformation(db.Model):
     __tablename__ = 'additional_information'
     
     id = db.Column(db.Integer, primary_key=True)
-    why_ca = db.Column(db.String, nullable=False)
-    additional_comments = db.Column(db.String, nullable=True)
-    student_id = db.Column(db.String, db.ForeignKey('applicant_information.student_id'), nullable=False)
+    why_ca = db.Column(db.String(1000), nullable=False)
+    additional_comments = db.Column(db.String(1000), nullable=True)
+    student_id = db.Column(db.String(50), db.ForeignKey('applicant_information.student_id'), nullable=False)


### PR DESCRIPTION
I fixed MySQL VARCHAR length requirements by setting appropriate lengths for the fields we used for the application to resolve the deployment error on Heroku.
We had initially not stated any specific string lengths for our database and we get a deployment error from Heroku because sqlachemy needs us to specify our string lengths so we run into a compile error.