### PR TITLE
Adding unit tests for models

### DIFF
--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,8 +1,154 @@
 import pytest
-from website.models import ApplicantInformation, AssessmentForm
+from datetime import date, time
+from website.models import (
+    Admin,
+    ApplicantInformation,
+    Appointment,
+    ApplicantPreferences,
+    AdditionalInformation,
+    AssessmentForm
+)
+from werkzeug.security import generate_password_hash
 from sqlalchemy.exc import IntegrityError
 import uuid
 
+
+@pytest.fixture
+def db_session(db):
+    """Fixture to handle database session cleanup."""
+    yield db.session
+    db.session.rollback()
+
+
+def test_admin_model(db_session):
+    admin = Admin(email="admin@example.com", password_hash=generate_password_hash("password"))
+    db_session.add(admin)
+    db_session.commit()
+
+    fetched_admin = Admin.query.filter_by(email="admin@example.com").first()
+    assert fetched_admin is not None
+    assert fetched_admin.check_password("password")
+    assert str(fetched_admin) == "<Admin admin@example.com>"
+
+
+def test_applicant_information_model(db_session):
+    applicant = ApplicantInformation(
+        last_name="Doe",
+        first_name="John",
+        preferred_name="Johnny",
+        pronouns="he/him",
+        student_id="12345_test1",
+        current_hall="Sample Hall",
+        current_room_number="101",
+        current_email="john.doe@example.com",
+        current_phone_number="555-1234",
+        returning_ca_or_new_ca="New",
+        major_1="CS",
+        class_year="2025",
+        cumulative_gpa=3.9,
+        leadership_experience={"clubs": ["Tech Club", "Art Society"]},
+    )
+    db_session.add(applicant)
+    db_session.commit()
+
+    # Query the applicant
+    fetched_applicant = ApplicantInformation.query.filter_by(student_id="12345_test1").first()
+    assert fetched_applicant is not None
+    assert fetched_applicant.get_interview_status() == "Yet To Schedule"
+    assert str(fetched_applicant) == "<ApplicantInformation John Doe>"
+
+
+def test_appointment_model(db_session):
+    applicant = ApplicantInformation(
+        last_name="Doe",
+        first_name="John",
+        pronouns="he/him",
+        student_id="12345_test2",
+        current_hall="Sample Hall",
+        current_room_number="101",
+        current_email="john.doe@example.com",
+        current_phone_number="555-1234",
+        returning_ca_or_new_ca="New",
+        major_1="CS",
+        class_year="2025",
+        cumulative_gpa=3.9,
+        leadership_experience={"clubs": ["Tech Club", "Art Society"]},
+    )
+    db_session.add(applicant)
+    db_session.commit()
+
+    appointment = Appointment(student_id="12345_test2", date=date(2023, 12, 1), time=time(10, 0))
+    db_session.add(appointment)
+    db_session.commit()
+
+    fetched_appointment = Appointment.query.filter_by(student_id="12345_test2").first()
+    assert fetched_appointment is not None
+    assert str(fetched_appointment) == "<Appointment for 12345_test2 on 2023-12-01 at 10:00:00>"
+
+
+def test_applicant_preferences_model(db_session):
+    applicant = ApplicantInformation(
+        last_name="Doe",
+        first_name="John",
+        pronouns="he/him",
+        student_id="12345_test3",
+        current_hall="Sample Hall",
+        current_room_number="101",
+        current_email="john.doe@example.com",
+        current_phone_number="555-1234",
+        returning_ca_or_new_ca="New",
+        major_1="CS",
+        class_year="2025",
+        cumulative_gpa=3.9,
+        leadership_experience={"clubs": ["Tech Club", "Art Society"]},
+    )
+    db_session.add(applicant)
+    db_session.commit()
+
+    preferences = ApplicantPreferences(
+        substance_free_housing_interest=5,
+        healthy_colby_interest="Yes",
+        population_interest="All",
+        staff_interest={"staff": ["RA", "Mentor"]},
+        illc_interest="No",
+        student_id="12345_test3",
+    )
+    db_session.add(preferences)
+    db_session.commit()
+
+    fetched_preferences = ApplicantPreferences.query.filter_by(student_id="12345_test3").first()
+    assert fetched_preferences is not None
+
+
+def test_additional_information_model(db_session):
+    applicant = ApplicantInformation(
+        last_name="Doe",
+        first_name="John",
+        pronouns="he/him",
+        student_id="12345_test4",
+        current_hall="Sample Hall",
+        current_room_number="101",
+        current_email="john.doe@example.com",
+        current_phone_number="555-1234",
+        returning_ca_or_new_ca="New",
+        major_1="CS",
+        class_year="2025",
+        cumulative_gpa=3.9,
+        leadership_experience={"clubs": ["Tech Club", "Art Society"]},
+    )
+    db_session.add(applicant)
+    db_session.commit()
+
+    additional_info = AdditionalInformation(
+        why_ca="I enjoy helping others.",
+        additional_comments="No additional comments.",
+        student_id="12345_test4",
+    )
+    db_session.add(additional_info)
+    db_session.commit()
+
+    fetched_additional_info = AdditionalInformation.query.filter_by(student_id="12345_test4").first()
+    assert fetched_additional_info is not None
 
 @pytest.fixture
 def applicant_data():


### PR DESCRIPTION
This pull request introduces several new unit tests for the models in the `website` application. These tests ensure that the models are correctly implemented and that their methods function as expected. Additionally, a new fixture for handling database session cleanup has been added.

Ticket: https://github.com/agpalm25/Epic_Exec_CS321_CORE_APP/issues/62

New unit tests and fixtures:

* Added imports for `date`, `time`, and various models in `tests/unit/test_models.py` to support the new tests.
* Introduced a `db_session` fixture to handle database session cleanup after each test.
* Created unit tests for the `Admin` model, including tests for password hashing and retrieval.
* Added unit tests for the `ApplicantInformation` model, including tests for creating and querying applicants.
* Implemented unit tests for the `Appointment`, `ApplicantPreferences`, and `AdditionalInformation` models to verify their creation and data retrieval.