### PR TITLE
Status Feedback for Interview Scheduling

### DIFF
--- a/tests/functional/test_appointment_page.py
+++ b/tests/functional/test_appointment_page.py
@@ -7,7 +7,7 @@ def test_appointment_page(client, app_context):
     assert response.status_code == 200
     assert b"Schedule Interview Appointment" in response.data
 
-def test_appointment_submission(client, db, app_context):
+def test_appointment_submission_success(client, db, app_context):
     # Creates an applicant for testing
     applicant = ApplicantInformation(
         student_id='12345',
@@ -29,7 +29,6 @@ def test_appointment_submission(client, db, app_context):
     db.session.add(applicant)
     db.session.commit()
 
-    # Submits an appointment here
     response = client.post(url_for('main.appt_submit'), data={
         'student_id': '12345',
         'apptDate': '2024-01-01',
@@ -37,10 +36,32 @@ def test_appointment_submission(client, db, app_context):
     }, follow_redirects=True)
 
     assert response.status_code == 200
-    print("Response content:", response.data.decode())  
-    assert b"Appointment scheduled successfully" in response.data or b"Thank you for scheduling your interview!" in response.data
-
-    # Checks if an appointment was created in the database
+    print("Response content:", response.data.decode())
+    assert b'<div class="alert alert-success">Appointment scheduled successfully! A confirmation email has been sent.</div>' in response.data
     appointment = Appointment.query.filter_by(student_id='12345').first()
     assert appointment is not None
     assert appointment.date.strftime('%Y-%m-%d') == '2024-01-01'
+
+def test_appointment_submission_no_applicant(client, db, app_context):
+    # Attempts to submit an appointment for a non-existent applicant
+    response = client.post(url_for('main.appt_submit'), data={
+        'student_id': '99999',
+        'apptDate': '2024-01-01',
+        'apptTime': '14:00'
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    assert b'<div class="alert alert-error">No application found for this student ID. Please submit an application first.</div>' in response.data
+    appointment = Appointment.query.filter_by(student_id='99999').first()
+    assert appointment is None
+
+def test_flash_messages_display(client, app_context):
+    # Test if flash messages are displayed correctly in the appointment page
+    with client.session_transaction() as session:
+        session['_flashes'] = [
+            ('success', 'Test success message'),
+            ('error', 'Test error message')
+        ]
+    response = client.get(url_for('main.appointment'))
+    assert response.status_code == 200
+    assert b'<div class="alert alert-success">Test success message</div>' in response.data
+    assert b'<div class="alert alert-error">Test error message</div>' in response.data

--- a/website/templates/appointment.html
+++ b/website/templates/appointment.html
@@ -157,6 +157,14 @@
         <h1 class="display-1">Schedule an Interview Appointment</h1>
 
         <div class="container">
+            <!-- Flash messages section -->
+            {% with messages = get_flashed_messages(with_categories=true) %}
+                {% if messages %}
+                    {% for category, message in messages %}
+                        <div class="alert alert-{{ category }}">{{ message }}</div>
+                    {% endfor %}
+                {% endif %}
+            {% endwith %}
 
         <div class="apptTransparentBackground">
             <form action="/apptSubmit" method="post" class="apptForm">
@@ -187,10 +195,6 @@
 
     <script>
         document.querySelector('.apptForm').addEventListener('submit', function(e) {
-            e.preventDefault();
-            document.getElementById('apptWait').style.display = 'none';
-            document.getElementById('apptThanks').style.display = 'block';
-            this.submit();
         });
     </script>
 </body>


### PR DESCRIPTION
This PR adds visual feedback to inform applicants about their interview scheduling status directly on the webpage.

Changes

Updated appointment.html to display flash messages
Added new tests for appointment status feedback:

Success message display
Error handling for non-existent applicants
Flash message structure validation


Testing
All tests pass:

test_appointment_page
test_appointment_submission_success
test_appointment_submission_no_applicant
test_flash_messages_display

Closes #59 
![Screenshot 2024-12-08 175441](https://github.com/user-attachments/assets/ef5e5db3-6893-44e4-9c17-fb4e65a5de12)
![Screenshot 2024-12-08 175725](https://github.com/user-attachments/assets/70cf6642-75cf-44ee-8e7c-1894e798366e)
![Screenshot 2024-12-08 175748](https://github.com/user-attachments/assets/79b841eb-dd9b-469c-83a0-d470ef56ffa5)
