### PR TITLE
Feature to Allow Alphanumeric Room Numbers in Application Form

### DIFF
--- a/tests/functional/test_appointment_page.py
+++ b/tests/functional/test_appointment_page.py
@@ -7,7 +7,7 @@ def test_appointment_page(client, app_context):
     assert response.status_code == 200
     assert b"Schedule Interview Appointment" in response.data
 
-def test_appointment_submission(client, db, app_context):
+def test_appointment_submission_success(client, db, app_context):
     # Creates an applicant for testing
     applicant = ApplicantInformation(
         student_id='12345',
@@ -29,7 +29,6 @@ def test_appointment_submission(client, db, app_context):
     db.session.add(applicant)
     db.session.commit()
 
-    # Submits an appointment here
     response = client.post(url_for('main.appt_submit'), data={
         'student_id': '12345',
         'apptDate': '2024-01-01',
@@ -37,10 +36,32 @@ def test_appointment_submission(client, db, app_context):
     }, follow_redirects=True)
 
     assert response.status_code == 200
-    print("Response content:", response.data.decode())  
-    assert b"Appointment scheduled successfully" in response.data or b"Thank you for scheduling your interview!" in response.data
-
-    # Checks if an appointment was created in the database
+    print("Response content:", response.data.decode())
+    assert b'<div class="alert alert-success">Appointment scheduled successfully! A confirmation email has been sent.</div>' in response.data
     appointment = Appointment.query.filter_by(student_id='12345').first()
     assert appointment is not None
     assert appointment.date.strftime('%Y-%m-%d') == '2024-01-01'
+
+def test_appointment_submission_no_applicant(client, db, app_context):
+    # Attempts to submit an appointment for a non-existent applicant
+    response = client.post(url_for('main.appt_submit'), data={
+        'student_id': '99999',
+        'apptDate': '2024-01-01',
+        'apptTime': '14:00'
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    assert b'<div class="alert alert-error">No application found for this student ID. Please submit an application first.</div>' in response.data
+    appointment = Appointment.query.filter_by(student_id='99999').first()
+    assert appointment is None
+
+def test_flash_messages_display(client, app_context):
+    # Test if flash messages are displayed correctly in the appointment page
+    with client.session_transaction() as session:
+        session['_flashes'] = [
+            ('success', 'Test success message'),
+            ('error', 'Test error message')
+        ]
+    response = client.get(url_for('main.appointment'))
+    assert response.status_code == 200
+    assert b'<div class="alert alert-success">Test success message</div>' in response.data
+    assert b'<div class="alert alert-error">Test error message</div>' in response.data

--- a/website/templates/application.html
+++ b/website/templates/application.html
@@ -232,7 +232,7 @@
 
                 <div class="col-md-6">
                     <label for="cur_room_num" class="form-label">Current Room Assignment (Room Number): </label>
-                    <input type="number" id="cur_room_num" name="cur_room_num" min="000" max="999" class="form-control"> <br>
+                    <input type="text" id="cur_room_num" name="cur_room_num" class="form-control" pattern="^[0-9]{1,3}[A-Za-z]?$" title="Please enter a valid room number (e.g., 100, 100A)"> <br>
                     
                 </div>
 

--- a/website/templates/appointment.html
+++ b/website/templates/appointment.html
@@ -157,6 +157,14 @@
         <h1 class="display-1">Schedule an Interview Appointment</h1>
 
         <div class="container">
+            <!-- Flash messages section -->
+            {% with messages = get_flashed_messages(with_categories=true) %}
+                {% if messages %}
+                    {% for category, message in messages %}
+                        <div class="alert alert-{{ category }}">{{ message }}</div>
+                    {% endfor %}
+                {% endif %}
+            {% endwith %}
 
         <div class="apptTransparentBackground">
             <form action="/apptSubmit" method="post" class="apptForm">
@@ -187,10 +195,6 @@
 
     <script>
         document.querySelector('.apptForm').addEventListener('submit', function(e) {
-            e.preventDefault();
-            document.getElementById('apptWait').style.display = 'none';
-            document.getElementById('apptThanks').style.display = 'block';
-            this.submit();
         });
     </script>
 </body>

--- a/website/templates/requirements_page.html
+++ b/website/templates/requirements_page.html
@@ -231,11 +231,11 @@
             
             </div>
             
-            <div class="requirement completed">
+            <div class="requirement">
                 
-                <input type="checkbox" id="requirement6" checked>
+                <input type="checkbox" id="requirement6">
                 <label for="requirement6">Leadership and Communication Skills</label>
-                <p class="white_text">Candidates should possess or be willing to develop strong leadership, communication, and conflict-resolution skills to effectively support and guide their peers.</p>
+                <p>Candidates should possess or be willing to develop strong leadership, communication, and conflict-resolution skills to effectively support and guide their peers.</p>
             
             </div>
         </div>


### PR DESCRIPTION
Modified the room number input field in the application form to:
Accept alphanumeric values by changing the input type from "number" to "text"
Add pattern validation to ensure proper format (1-3 digits optionally followed by a letter)
Include a helpful tooltip explaining the expected format
Remove the previous numeric-only restrictions
Users can now enter room numbers like "100A"
Invalid formats (like "A100" or "1000B") are prevented
Closes #78 
![Screenshot 2024-12-08 182429](https://github.com/user-attachments/assets/5874b9d1-1286-4bea-8ca2-151858eb61d2)
![Screenshot 2024-12-08 182730](https://github.com/user-attachments/assets/b83e4c58-4148-4a64-9cef-af0683187110)
