### PR TITLE
Fixed email notifications for CA application decisions

### DIFF
--- a/website/email_sender.py
+++ b/website/email_sender.py
@@ -78,3 +78,93 @@ def send_interview_confirmation_email(applicant_email, full_name, date, time):
     """
    
     return send_email(applicant_email, subject, body)
+
+def send_assessment_result_email(applicant_email, preferred_name, last_name, student_id, result):
+    if result == "Accepted":
+        subject = "CA Offer Letter"
+        body = f"""
+        {preferred_name} {last_name}
+        {student_id}
+
+        Dear {preferred_name},
+
+        Congratulations! The Office of Campus Life is pleased to offer you a Community Advisor position for the 2025-2026 academic year. On behalf of the Office, we are truly excited to welcome you to our team!
+
+        The Community Advisor position is specifically designated as a full academic year position. The position responsibilities and expectations are described in the position description and the 2025-2026 Community Advisor Position Agreement. The period of employment begins as early as TBD, and ends TBD. The employment period includes training, and break closings/openings.
+
+        If accepting the position, you will be given your placement, and your supervising ARD no later than TBD. 
+
+        Please understand that this is a conditional position offer. Your offer and employment for the upcoming academic year is contingent upon the successful completion of the following:
+        Maintaining a minimum 2.50 cumulative grade point average (GPA) - GPAs will be checked at the conclusion of each semester. If you do not meet the GPA requirement, you will be notified; and
+        Remain in good student conduct standing with the College.
+
+        In order to accept this offer, please complete the following:
+        Review the 2025-2026 Community Advisor Position Agreement. This agreement outlines position obligations and responsibilities, important dates, and sets forth employment guidelines; 
+        Electronically accept or decline the offered position by no later than TBD.
+
+        If accepting the position, please officially apply through Workday. This application does not have any determination on your hireability as we have already gone through a hiring process. This form instead helps process and prepare for your employment.
+        In Workday, Search for "Find Student Jobs" and click on Find Student Jobs – CR (report).
+        Scroll through the jobs and review job descriptions which can also be found in the job book. It's helpful to search for Community Advisor or by "R0003473."
+        Apply by clicking on the Apply button and uploading a resume and cover letter to express your interest.
+
+        Save the Date - August Training: Per the 2025-2026 Community Advisor Position Agreement, you are required to attend Fall Hall Staff Training beginning as early as TBD. Training and move-in preparations will continue through the first day of classes. Please use these dates for planning purposes. 
+
+        Please Note: Employment timeframes are aligned with the Colby College Academic Calendar but may require flexibility should circumstances arise that cause a shift in the academic calendar. In this event, Community Advisors will be notified as to any impact on the employment dates and time frame as soon as possible and once those shifts are finalized. In the spirit of professional courtesy and etiquette, please notify all supervisors, coaches, or anyone who may be impacted by these dates so you do not have any conflicts for training. This includes outside/family activities, employment, and/or any other college-related positions, activities, or athletics. All travel arrangements must be made with an understanding of the training date requirements.
+
+        Should you have any questions or concerns regarding this offer that might affect your acceptance, please contact Kyle Arthenayake, Associate Director of Residential Education (karthena@colby.edu) or Shikha Shrestha, Assistant Director of Residential Education (shshrest@colby.edu). 
+
+        Once again, congratulations! I look forward to working with you on Hall Staff next year.
+
+        Sincerely,
+        Colby's Office of the Residential Experience (CORE)
+        """
+    elif result == "Waitlisted":
+        subject = "CA Alternate Offer"
+        body = f"""
+        {preferred_name} {last_name}
+        {student_id}
+
+        Dear {preferred_name},
+
+        On behalf of the Office of Residential Experience, I would like to take this opportunity to thank you for your interest and participation in the Community Advisor selection process. This year's selection process for the Community Advisor position was extremely competitive, particularly given the quality of applicants seeking a role. This made position deliberations incredibly difficult. 
+
+        After a complete assessment of our positions and communities and a full review of all potential candidates, we are unfortunately unable to offer you an official position at this immediate time. However, we are pleased to offer you an Alternate Community Advisor position. Our interview team was impressed with your skills, experiences, and enthusiasm, and we believe you have the skills to be a Community Advisor.
+
+        Why should you consider the Alternate Community Advisor status?
+        The role of the Alternate Community Advisor (CA) is critical if a CA position becomes available for the upcoming academic year
+        It is not uncommon that Alternate Community Advisors may receive an offer as early as TBD, or throughout the summer (should positions become available).
+        If a Community Advisor position does become available (including those created by CAs going abroad), we will consider our Alternate Community Advisor pool to choose a replacement.
+        If a position becomes available, you will be considered if we believe you would be a good fit for the particular staff and floor/building community with the opening.
+
+        In order to share your decision regarding this offer, please complete the following:
+        Electronically accept or decline the offered position by no later than TBD
+
+        Please understand that this is a conditional position offer. Serving as an Alternate Community Advisor for the upcoming academic year is contingent upon the successful completion of the following:
+        Maintaining a minimum 2.50 cumulative grade point average (GPA) - GPAs will be checked after each semester. If you do not meet the GPA requirement, you will be notified; and
+        Remaining in good student conduct standing with the College.
+
+        Something to Keep in Mind: As an Alternate Community Advisor, you may receive an offer for a position. As such, all Community Advisors for the 2025-2026 academic year will be required to attend Fall Hall Staff Training beginning as early as TBD. Training and move-in preparations would continue through the first day of classes. Please be mindful of these dates should you receive an offer at any point.
+
+        At any time after accepting this role, if you would like to remove yourself from consideration (due to accepting another position, no longer being interested, or for any other reason) or if you have any questions, please feel free to contact Kyle Arthenayake, Associate Director of Residential Education (karthena@colby.edu) or Shikha Shrestha, Assistant Director of Residential Education (shshrest@colby.edu). 
+
+        Sincerely,
+        Colby's Office of the Residential Experience (CORE)
+        """
+    else:  # Rejected
+        subject = "CA Regret Letter"
+        body = f"""
+        {preferred_name} {last_name}
+
+        Dear {preferred_name},
+
+        Thank you for your participation in the Community Advisor Selection Process. We appreciate your interest, application, and investment in the process. This year's selection process for Community Advisor positions was extremely competitive, particularly given the quality of applicants. This made position deliberations incredibly difficult. 
+
+        After a complete and thorough assessment of the Hall Staff team's needs and after a full review of all potential candidates, I regret to inform you that the Office of the Residential Experience cannot offer you a Community Advisor position at this time.
+ 
+        Thank you again for your time, energy, and commitment to the Apartment Community Advisor selection process. Should you have any questions please don't hesitate to reach out.
+
+        Sincerely,
+        Colby's Office of the Residential Experience (CORE)
+        """
+    
+    return send_email(applicant_email, subject, body)


### PR DESCRIPTION
 Updated email templates for CA Offer, Regret, and Alternate letters
 Fixed parameter passing in views.py assess_applicant function
 Ensured proper email sending for accepted/rejected/waitlisted statuses
 Added error handling for email sending failures.